### PR TITLE
📕 #33 Scan 컴포넌트 로직 분리

### DIFF
--- a/src/components/scan/CameraControls.tsx
+++ b/src/components/scan/CameraControls.tsx
@@ -1,0 +1,46 @@
+import shutter from "../../icons/camera/camera_shutter.svg";
+import check from "../../icons/camera/check.svg";
+
+interface CameraControlsProps {
+    onTakePhoto: () => void;
+    onUpload: () => void;
+    isLoading: boolean;
+    hasCameraPermission: boolean;
+    hasPhotos: boolean;
+}
+
+export const CameraControls = ({
+                                   onTakePhoto,
+                                   onUpload,
+                                   isLoading,
+                                   hasCameraPermission,
+                                   hasPhotos,
+                               }: CameraControlsProps) => {
+    return (
+        <div className="relative w-full h-[187.5px] flex items-center justify-center bg-[#181A20]">
+            <div className="absolute take-button z-10">
+                <button
+                    onClick={onTakePhoto}
+                    disabled={isLoading}
+                    className={`flex items-center justify-center w-20 h-20 transition-opacity ${
+                        hasCameraPermission && !isLoading ? "opacity-100" : "opacity-50"
+                    }`}
+                >
+                    <img src={shutter} alt="촬영하기" className="w-full h-full" />
+                </button>
+            </div>
+
+            <div className="absolute gallery-button right-[62.5px] z-10">
+                <button
+                    onClick={onUpload}
+                    disabled={isLoading || !hasPhotos}
+                    className={`rounded-full ${!hasPhotos ? "opacity-50" : ""}`}
+                >
+                    <div className="relative">
+                        <img src={check} alt="변환하기" className="w-full h-full" />
+                    </div>
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/src/components/scan/PhotoPreview.tsx
+++ b/src/components/scan/PhotoPreview.tsx
@@ -1,0 +1,40 @@
+export interface PhotoFile {
+    id: string;
+    data: string;
+}
+
+interface PhotoPreviewProps {
+    photos: PhotoFile[];
+    onRemove: (id: string) => void;
+    isVisible: boolean;
+}
+
+export const PhotoPreview = ({ photos, onRemove, isVisible }: PhotoPreviewProps) => {
+    if (!isVisible || photos.length === 0) return null;
+
+    return (
+        <div className="absolute bottom-0 left-0 w-full py-3 bg-black/70 z-10">
+            <div className="mx-4">
+                <div className="flex overflow-x-auto gap-3 scrollbar-hide">
+                    {photos.map((photo) => (
+                        <div key={photo.id} className="flex-none relative">
+                            <img
+                                src={photo.data}
+                                alt="촬영된 사진"
+                                className="w-24 h-24 object-cover rounded-lg"
+                                style={{ aspectRatio: "1/1" }}
+                            />
+                            <button
+                                onClick={() => onRemove(photo.id)}
+                                className="text-[15px] absolute top-1 right-1 bg-red-500 rounded-full w-5 h-5 flex items-center justify-center text-white shadow-lg"
+                                style={{ borderRadius: "50%" }}
+                            >
+                                <span style={{ lineHeight: "100%" }}>✕</span>
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/scan/ScanViewer.tsx
+++ b/src/components/scan/ScanViewer.tsx
@@ -1,0 +1,57 @@
+import {Camera} from "react-camera-pro";
+import {PhotoPreview, PhotoFile} from "./PhotoPreview.tsx";
+
+interface ScanViewerProps {
+    cameraRef: React.RefObject<Camera>;
+    errorMessages: {
+        noCameraAccessible: string;
+        permissionDenied: string;
+        switchCamera: string;
+        canvas: string;
+    };
+
+    // PhotoPreview에 필요한 props 추가
+    photos: PhotoFile[];
+    onRemove: (id: string) => void;
+    isPreviewVisible: boolean;
+}
+
+export const ScanViewer = ({
+                               cameraRef,
+                               errorMessages,
+                               photos,
+                               onRemove,
+                               isPreviewVisible
+                           }: ScanViewerProps) => {
+    return (
+        <div className="relative w-[414px] h-[615px]">
+            <div style={{
+                position: "absolute",
+                width: "100%",
+                height: "100%",
+            }}>
+                <Camera
+                    ref={cameraRef}
+                    aspectRatio="cover"
+                    imageType="jpeg"
+                    errorMessages={errorMessages}
+                    style={{
+                        minWidth: "100%",
+                        minHeight: "100%",
+                        position: "absolute",
+                        left: "50%",
+                        top: "50%",
+                        transform: "translate(-50%, -50%)",
+                    }}
+                />
+            </div>
+
+            {/* PhotoPreview를 여기에 포함 */}
+            <PhotoPreview
+                photos={photos}
+                onRemove={onRemove}
+                isVisible={isPreviewVisible}
+            />
+        </div>
+    );
+};

--- a/src/hooks/useCameraState.ts
+++ b/src/hooks/useCameraState.ts
@@ -1,0 +1,33 @@
+import {useState} from "react";
+import {Camera} from "react-camera-pro";
+
+export const useCameraState = (cameraRef: React.RefObject<Camera>) => {
+    const [isPreviewVisible, setIsPreviewVisible] = useState(true);
+    const [cameraError, setCameraError] = useState<string | null>(null);
+
+    const resetCamera = () => {
+        setIsPreviewVisible(false);
+        setCameraError(null);
+        setTimeout(() => setIsPreviewVisible(true), 200);
+    };
+
+    const handleCameraError = (error: Error) => {
+        setCameraError(error.message);
+        if (error.message.includes("권한") || error.message.includes("접근")) {
+            alert("카메라 접근에 실패했습니다. 메인 페이지로 이동합니다.");
+            resetCamera();
+            return true;
+        }
+        alert("카메라 촬영에 실패했습니다. 다시 시도해주세요.");
+        resetCamera();
+        return false;
+    };
+
+    return {
+        isPreviewVisible,
+        cameraError,
+        resetCamera,
+        handleCameraError,
+        setCameraError
+    };
+};

--- a/src/hooks/usePhotoUpload.ts
+++ b/src/hooks/usePhotoUpload.ts
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { uploadImages } from '../api/image';
+
+interface PhotoFile {
+    id: string;
+    data: string;
+}
+
+interface UploadStatus {
+    success: boolean;
+    message: string;
+}
+
+interface UploadResult {
+    message: string;
+    // 기타 API 응답 필드들
+}
+
+export const UPLOAD_CONSTANTS = {
+    MAX_TOTAL_SIZE: 10 * 1024 * 1024, // 10MB
+    MIN_FILE_SIZE: 100, // 100 bytes
+    ALLOWED_TYPES: ['image/jpeg', 'image/jpg'],
+} as const;
+
+export const usePhotoUpload = () => {
+    const [isLoading, setIsLoading] = useState(false);
+    const [uploadStatus, setUploadStatus] = useState<UploadStatus | null>(null);
+
+    // 파일 유효성 검사
+    const validateFiles = (files: File[]): string | null => {
+        // 파일 존재 여부 확인
+        if (files.length === 0) {
+            return '업로드할 파일이 없습니다.';
+        }
+
+        // 각 파일 크기 확인
+        const validFiles = files.filter(file => file.size >= UPLOAD_CONSTANTS.MIN_FILE_SIZE);
+        if (validFiles.length === 0) {
+            return '유효한 이미지 파일이 없습니다.';
+        }
+
+        // 전체 크기 확인
+        const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+        if (totalSize > UPLOAD_CONSTANTS.MAX_TOTAL_SIZE) {
+            return '전체 파일 크기가 제한을 초과했습니다.';
+        }
+
+        return null;
+    };
+
+    // Base64를 File 객체로 변환
+    const convertBase64ToFile = async (photos: PhotoFile[]): Promise<File[]> => {
+        const filePromises = photos.map(async (photo) => {
+            const base64Response = await fetch(photo.data);
+            const blob = await base64Response.blob();
+            return new File([blob], `photo-${photo.id}.jpg`, {
+                type: 'image/jpeg'
+            });
+        });
+
+        return Promise.all(filePromises);
+    };
+
+    // 이미지 업로드 처리
+    const handleUpload = async (photos: PhotoFile[]): Promise<boolean> => {
+        if (isLoading || photos.length === 0) return false;
+
+        setIsLoading(true);
+        setUploadStatus(null);
+
+        try {
+            // Base64 -> File 변환
+            const files = await convertBase64ToFile(photos);
+
+            // 파일 유효성 검사
+            const validationError = validateFiles(files);
+            if (validationError) {
+                throw new Error(validationError);
+            }
+
+            // 이미지 업로드 API 호출
+            const response = await uploadImages({
+                title: "촬영된 이미지들",
+                files,
+            });
+
+            setUploadStatus({
+                success: true,
+                message: response.message,
+            });
+
+            return true;
+
+        } catch (error: any) {
+            let errorMessage: string;
+
+            if (error?.response?.status === 401) {
+                // 401 에러는 axios interceptor에서 처리
+                return false;
+            }
+
+            // API 에러 메시지 처리
+            errorMessage = error?.response?.data?.detail?.[0]?.msg
+                ?? error.message
+                ?? "이미지 업로드에 실패했습니다. 다시 시도해주세요.";
+
+            setUploadStatus({
+                success: false,
+                message: errorMessage,
+            });
+
+            return false;
+
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    // 상태 초기화
+    const resetUploadState = () => {
+        setIsLoading(false);
+        setUploadStatus(null);
+    };
+
+    return {
+        isLoading,
+        uploadStatus,
+        handleUpload,
+        resetUploadState,
+    };
+};

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -34,7 +34,7 @@ const Scan = () => {
         cameraError,
         resetCamera,
         handleCameraError,
-        setCameraError  // 이 부분이 필요합니다
+        setCameraError,
     } = useCameraState(cameraRef);
 
     const {

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -2,30 +2,41 @@ import React, {useRef, useState} from "react";
 import {Camera} from "react-camera-pro";
 import {useNavigate} from "react-router-dom";
 import {NavBar} from "../components/common/NavBar.tsx";
-import BookConvertModal from "../components/scan/BookConvertModal.tsx";
-import shutter from "../icons/camera/camera_shutter.svg";
-import check from "../icons/camera/check.svg";
+import {PhotoPreview} from "../components/scan/PhotoPreview.tsx";
+import {CameraControls} from "../components/scan/CameraControls.tsx";
 import {useCamera} from "../hooks/useCamera";
-import {uploadImages} from "../api/image";
+import {useCameraState} from "../hooks/useCameraState";
+import {usePhotoUpload} from "../hooks/usePhotoUpload";
+import {ScanViewer} from "../components/scan/ScanViewer.tsx";
+
+function CameraView(props: {
+    cameraRef: React.RefObject<Camera>,
+    errorMessages: { switchCamera: string; canvas: string; noCameraAccessible: string; permissionDenied: string }
+}) {
+    return null;
+}
 
 const Scan = () => {
-    // useNavigate : 페이지 이동을 위한 hook
     const navigate = useNavigate();
-
-    // useState Variables
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
-    const [isPreviewVisible, setIsPreviewVisible] = useState(true);
-    const [cameraError, setCameraError] = useState<string | null>(null);
-    const [uploadStatus, setUploadStatus] = useState<{
-        success: boolean;
-        message: string;
-    } | null>(null);
-
-    // useRef : 컴포넌트가 리렌더링되어도 값을 유지한다.
     const cameraRef = useRef<Camera>(null);
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
-    // Camera Hook에서 필요한 데이터를 반환한다.
+    // Custom Hooks
+    const {
+        isLoading,
+        uploadStatus,
+        handleUpload,
+        resetUploadState
+    } = usePhotoUpload();
+
+    const {
+        isPreviewVisible,
+        cameraError,
+        resetCamera,
+        handleCameraError,
+        setCameraError  // 이 부분이 필요합니다
+    } = useCameraState(cameraRef);
+
     const {
         hasCameraPermission,
         takePhoto,
@@ -34,139 +45,31 @@ const Scan = () => {
         removePhoto,
     } = useCamera(cameraRef);
 
-
-// 카메라 초기화를 위한 함수
-    const resetCamera = () => {
-        // 카메라 초기화 프로세스
-        // 촬영 데이터 초기화 -> 미리보기 제거 -> 로딩 종료 -> 카메라 에러 초기화 -> 상태 재설정
-
-        clearPhotos(); // 기존 촬영 데이터 초기화
-        setIsPreviewVisible(false); // 미리보기 완전히 숨기기
-        setIsLoading(false);
-        setCameraError(null);
-
-        // 컴포넌트 리렌더링을 위한 state 재설정
-        setTimeout(() => {
-            setIsPreviewVisible(true);
-        }, 200);
-    };
-
-// 카메라 에러를 분기하는 함수
-    const handleCameraError = (error: Error) => {
-        setCameraError(error.message);
-
-        // 심각한 카메라 에러인 경우 (권한 거부, 하드웨어 접근 불가 등)
-        if (error.message.includes("권한") || error.message.includes("접근")) {
-            alert("카메라 접근에 실패했습니다. 메인 페이지로 이동합니다.");
-            resetCamera();
-
-            navigate("/");
-            return;
-        }
-
-        // 일시적인 에러인 경우
-        alert("카메라 촬영에 실패했습니다. 다시 시도해주세요.");
-        resetCamera();
-    };
-
-// 카메라 촬영
+    // Event Handlers
     const handleTakePhoto = async () => {
-        // 카메라 권한이 없거나 로딩이 켜져있다면
         if (!hasCameraPermission || isLoading) return;
 
         try {
-            setIsLoading(true);
             setCameraError(null);
-
             const photo = await takePhoto();
-
-            if (photo && photo.data)
-                console.log("사진 촬영 성공:", photo.id);
-            else
+            if (!photo?.data) {
                 throw new Error("사진 데이터를 가져올 수 없습니다.");
+            }
         } catch (error) {
             handleCameraError(error as Error);
-        } finally {
-            setIsLoading(false);
         }
     };
 
-    const handleUpload = async () => {
-        // 업로드 중이거나 촬영된 사진이 없는 경우
-        if (isLoading || capturedPhotos.length === 0) return;
-
-        setIsLoading(true);
-        setUploadStatus(null);
-
-        try {
-            const filePromises = capturedPhotos.map(async (photo) => {
-                const base64Response = await fetch(photo.data);
-                const blob = await base64Response.blob();
-                return new File([blob], `photo-${photo.id}.jpg`, {type: "image/jpeg"});
-            });
-
-            const files = await Promise.all(filePromises);
-
-            // 모든 파일이 유효한지 확인 (100bytes 이상)
-            const validFiles = files.filter(file => file.size >= 100);
-            if (validFiles.length === 0) {
-                throw new Error('유효한 이미지 파일이 없습니다.');
-            }
-
-            // 업로드 전에 파일 크기 합계 확인 (API 명세의 제한사항)
-            const totalSize = validFiles.reduce((sum, file) => sum + file.size, 0);
-            if (totalSize > 10 * 1024 * 1024) { // 10MB 제한
-                throw new Error('전체 파일 크기가 너무 큽니다.');
-            }
-
-            const response = await uploadImages({
-                title: "촬영된 이미지들",
-                files: validFiles,
-            });
-
-            if (response) {
-                setUploadStatus({
-                    success: true,
-                    message: response.message,
-                });
-                setIsModalOpen(true);
-                clearPhotos();
-            }
-        } catch (error: any) {
-            let errorMessage;
-
-            switch (error?.response?.status) {
-                case 401:
-                    resetCamera();
-
-                    break;
-                default:
-                    errorMessage = "이미지 업로드에 실패했습니다. 다시 시도해주세요.";
-            }
-
-            if (error?.response?.status === 401) {
-                // 401 에러는 이제 axios interceptor에서 처리되므로,
-                // auth:unauthorized 이벤트를 통해 처리됨
-            } else {
-                // API 명세에 맞는 에러 메시지 처리
-                // ?.로 접근하고 error.message 없으면 문자열 반환
-                errorMessage = error?.response?.data?.detail?.[0]?.msg
-                    ?? error.message
-                    ?? "이미지 업로드에 실패했습니다. 다시 시도해주세요.";
-
-                setUploadStatus({
-                    success: false,
-                    message: errorMessage,
-                });
-
-            }
+    const handlePhotoUpload = async () => {
+        if (await handleUpload(capturedPhotos)) {
+            setIsModalOpen(true);
+            clearPhotos();
+        } else {
             resetCamera();
-        } finally {
-            setIsLoading(false);
         }
     };
 
-// 카메라 에러 상태에 따른 UI 처리
+    // Error View
     if (cameraError) {
         return (
             <div className="w-full h-screen flex flex-col items-center justify-center bg-gray-900 text-white">
@@ -185,106 +88,30 @@ const Scan = () => {
     return (
         <div className="content-wrapper ml-[32px] mr-[32px] md-[34px] w-[350px] flex flex-col items-center h-[896px]">
             <div className="w-full">
-                <NavBar title="스캔하기"/>
+                <NavBar title="스캔하기" />
             </div>
 
-            {/* Camera View */}
-            <div className="relative w-[414px] h-[615px]">
-                <div
-                    style={{
-                        position: "absolute",
-                        width: "100%",
-                        height: "100%",
-                    }}
-                >
-                    <Camera
-                        ref={cameraRef}
-                        aspectRatio="cover"
-                        imageType="jpeg"
-                        errorMessages={{
-                            noCameraAccessible: "카메라에 접근할 수 없습니다.",
-                            permissionDenied: "카메라 권한이 거부되었습니다.",
-                            switchCamera: "카메라를 전환할 수 없습니다.",
-                            canvas: "캔버스를 사용할 수 없습니다.",
-                        }}
-                        style={{
-                            minWidth: "100%",
-                            minHeight: "100%",
-                            position: "absolute",
-                            left: "50%",
-                            top: "50%",
-                            transform: "translate(-50%, -50%)",
-                        }}
-                    />
-                </div>
-                {/* Preview Section */}
-                {capturedPhotos.length > 0 && isPreviewVisible && (
-                    <div className="absolute bottom-0 left-0 w-full py-3 bg-black/70">
-                        <div className="mx-4">
-                            <div className="flex overflow-x-auto gap-3 scrollbar-hide">
-                                {capturedPhotos.map((photo) => (
-                                    <div key={photo.id}
-                                         className="flex-none relative">
-                                        <img
-                                            src={photo.data}
-                                            alt="촬영된 사진"
-                                            className="w-24 h-24 object-cover rounded-lg"
-                                            style={{aspectRatio: "1/1"}}
-                                        />
-                                        <button
-                                            onClick={() => removePhoto(photo.id)}
-                                            className="text-[15px] absolute top-1 right-1 bg-red-500 rounded-full w-5 h-5 flex items-center justify-center text-white shadow-lg"
-                                            style={{borderRadius: "50%"}}
-                                        >
-                                            <span style={{lineHeight: "100%"}}>✕</span>
-                                        </button>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    </div>
-                )}
-            </div>
-
-            {/* Controls */}
-            <div className="relative w-full h-[187.5px] flex items-center justify-center bg-[#181A20]">
-                {/* 촬영 버튼 */}
-                <div className="absolute take-button z-10">
-                    <button
-                        onClick={handleTakePhoto}
-                        disabled={isLoading}
-                        className={`flex items-center justify-center w-20 h-20 transition-opacity ${
-                            hasCameraPermission && !isLoading ? "opacity-100" : "opacity-50"
-                        }`}
-                    >
-                        <img src={shutter}
-                             alt="촬영하기"
-                             className="w-full h-full"/>
-                    </button>
-                </div>
-
-                {/* 업로드 버튼 */}
-                <div className="absolute gallery-button right-[62.5px] z-10">
-                    <button
-                        onClick={handleUpload}
-                        disabled={isLoading || capturedPhotos.length === 0}
-                        className={`rounded-full ${
-                            capturedPhotos.length === 0 ? "opacity-50" : ""
-                        }`}
-                    >
-                        <div className="relative">
-                            <img src={check}
-                                 alt="변환하기"
-                                 className="w-full h-full"/>
-                        </div>
-                    </button>
-                </div>
-            </div>
-            <BookConvertModal
-                isOpen={isModalOpen}
-                onClose={() => setIsModalOpen(false)}
-                uploadStatus={uploadStatus}
+            <ScanViewer
+                cameraRef={cameraRef}
+                errorMessages={{
+                    noCameraAccessible: "카메라에 접근할 수 없습니다.",
+                    permissionDenied: "카메라 권한이 거부되었습니다.",
+                    switchCamera: "카메라를 전환할 수 없습니다.",
+                    canvas: "캔버스를 사용할 수 없습니다.",
+                }}
+                photos={capturedPhotos}
+                onRemove={removePhoto}
+                isPreviewVisible={isPreviewVisible}
             />
+
+            <CameraControls
+                onTakePhoto={handleTakePhoto}
+                onUpload={handlePhotoUpload}
+                isLoading={isLoading}
+                hasCameraPermission={hasCameraPermission}
+                hasPhotos={capturedPhotos.length > 0}
+            />
+
         </div>
     );
 };


### PR DESCRIPTION
## 📗 작업 내용
- `Scan` 컴포넌트의 로직을 재사용성 확보 및 로직과 렌더링 분리 목적으로 리팩터링 진행

### ✅ PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### ✅ 변경 사항
- `Scan` 컴포넌트에 모여진 로직을 각 `CustomHook`과 `Seg Component`로 분리하였음

### ✅ 참고 사항
- `Claude`와 함께 했기 때문에 로직 분석 필요
