### PR TITLE
📕 #49 ScanVertex 페이지 퍼블리싱 및 API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import MainLayout from "./components/common/MainLayout";
 import {API_TYPE, ROUTES} from "./routes/constants";
 import AiAssistant from "./pages/AiAssistant.tsx";
 import GoodsStorage from "./pages/GoodsStorage.tsx";
+import ScanVertex from "./pages/ScanVertex.tsx";
 
 const App = () => {
     // 서버 경로 체크 함수
@@ -42,6 +43,8 @@ const App = () => {
                                 element={<Home/>}/>
                         <Route path={ROUTES.SCAN.path}
                                 element={<Scan/>}/>
+                        <Route path={ROUTES.SCANVERTEX.path}
+                                element={<ScanVertex/>}/>
                         <Route path={ROUTES.PLAYER.AUDIO.path}
                                 element={<Player/>}/>
                         <Route path={ROUTES.PLAYER.PDF.path}

--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -1,8 +1,13 @@
 import axiosInstance, { uploadInstance } from "./axios";
 
+interface UploadImageItem {
+  file: File;
+  vertices?: { x: number; y: number }[];
+}
+
 interface UploadImagesParams {
   title: string;
-  files: File[];
+  files: UploadImageItem[];
 }
 
 interface ImageUploadResponse {
@@ -22,11 +27,14 @@ export const uploadImages = async ({ title, files }: UploadImagesParams): Promis
   formData.append('storage_name', '책');
   formData.append('title', title);
 
-  for (const file of files) {
-    if (file.size > 5 * 1024 * 1024) {
+  for (const [index, item] of files.entries()) {
+    if (item.file.size > 5 * 1024 * 1024) {
       throw new Error('파일 크기가 너무 큽니다. 5MB 이하의 파일만 업로드 가능합니다.');
     }
-    formData.append('files', file);
+    formData.append('files', item.file);
+    if (item.vertices) {
+      formData.append(`vertices[${index}]`, JSON.stringify(item.vertices));
+    }
   }
 
   // axios 인스턴스를 사용해 서버에 POST 요청
@@ -46,7 +54,7 @@ export const uploadImages = async ({ title, files }: UploadImagesParams): Promis
         }
       }
     );
-    
+
     return data;
   } catch (error: any) {
     throw new Error('글자가 잘 나오도록 다시 찍어 주세요! 😊');

--- a/src/components/scan/BookConvertModal.tsx
+++ b/src/components/scan/BookConvertModal.tsx
@@ -4,6 +4,10 @@ import {useNavigate} from "react-router-dom";
 interface PhotoFile {
     id: string;
     data: string;
+    vertices?: {
+        x: number;
+        y: number;
+    }[];
 }
 
 interface BookConvertModalProps {
@@ -15,12 +19,12 @@ interface BookConvertModalProps {
 }
 
 const BookConvertModal: React.FC<BookConvertModalProps> = ({
-                                                               photos,
-                                                               onClose,
-                                                               onUpload,
-                                                               onComplete,
-                                                               isLoading,
-                                                           }) => {
+                                                                photos,
+                                                                onClose,
+                                                                onUpload,
+                                                                onComplete,
+                                                                isLoading,
+                                                            }) => {
     const navigate = useNavigate();
     const [step, setStep] = useState<number>(1);
     const [bookTitle, setBookTitle] = useState<string>("");
@@ -62,15 +66,40 @@ const BookConvertModal: React.FC<BookConvertModalProps> = ({
         setStep(2);
 
         try {
+            // vertices 정보와 함께 photos 로그 출력
+            console.log('Photos with vertices:', photos.map(photo => ({
+                id: photo.id,
+                hasVertices: !!photo.vertices,
+                verticesData: photo.vertices
+            })));
+
             // bookTitle을 onUpload 함수에 전달
             const uploadResult = await onUpload(photos, bookTitle);
 
+            // 업로드 시도할 데이터 구조 확인
+            console.log('Upload payload:', {
+                title: bookTitle,
+                photos: photos.map(photo => ({
+                    id: photo.id,
+                    data: photo.data.substring(0, 50) + '...', // 데이터는 길어서 축약
+                    vertices: photo.vertices
+                }))
+            });
+
             if (uploadResult) {
                 setStep(3);
+                // 성공 시 최종 상태 로그
+                console.log('Upload successful!', {
+                    title: bookTitle,
+                    photoCount: photos.length,
+                    photosWithVertices: photos.filter(p => p.vertices).length
+                });
             } else {
                 setStep(1);
+                console.log('Upload failed');
             }
         } catch (error) {
+            console.error('Upload error:', error);
             setStep(1);
         }
     };

--- a/src/hooks/useScanStore.ts
+++ b/src/hooks/useScanStore.ts
@@ -1,0 +1,39 @@
+import create from 'zustand';
+
+interface PhotoFile {
+    id: string;
+    data: string;
+    vertices?: {
+        x: number;
+        y: number;
+    }[];
+}
+
+interface ScanStore {
+    photos: PhotoFile[];
+    addPhoto: (photo: PhotoFile) => void;
+    updatePhotoVertices: (photoId: string, vertices: { x: number; y: number; }[]) => void;
+    removePhoto: (id: string) => void;
+    clearPhotos: () => void;
+}
+
+export const useScanStore = create<ScanStore>((set) => ({
+    photos: [],
+    addPhoto: (photo) => 
+        set((state) => ({
+            photos: [...state.photos, photo]
+        })),
+    updatePhotoVertices: (photoId, vertices) =>
+        set((state) => ({
+            photos: state.photos.map(photo =>
+                photo.id === photoId 
+                    ? { ...photo, vertices } 
+                    : photo
+            )
+        })),
+    removePhoto: (id) =>
+        set((state) => ({
+            photos: state.photos.filter(photo => photo.id !== id)
+        })),
+    clearPhotos: () => set({ photos: [] })
+}));

--- a/src/pages/ScanVertex.tsx
+++ b/src/pages/ScanVertex.tsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { NavBar } from '../components/common/NavBar';
+import { useScanStore } from '../hooks/useScanStore';
+
+interface Vertex {
+    x: number;
+    y: number;
+}
+
+interface LocationState {
+    photoId: string;
+    photoData: string;
+}
+
+interface ImageBounds {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+const ScanVertex: React.FC = () => {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const svgRef = useRef<SVGSVGElement>(null);
+    const imgRef = useRef<HTMLImageElement>(null);
+    const { photoId, photoData } = location.state as LocationState;
+    const { updatePhotoVertices } = useScanStore();
+    const [vertices, setVertices] = useState<Vertex[]>([]);
+    const [activeVertex, setActiveVertex] = useState<number | null>(null);
+    const [imageBounds, setImageBounds] = useState<ImageBounds | null>(null);
+
+    useEffect(() => {
+        if (activeVertex !== null) {
+            document.addEventListener('mousemove', handleVertexDrag);
+            document.addEventListener('mouseup', handleVertexDragEnd);
+            document.addEventListener('touchmove', handleVertexDrag);
+            document.addEventListener('touchend', handleVertexDragEnd);
+
+            return () => {
+                document.removeEventListener('mousemove', handleVertexDrag);
+                document.removeEventListener('mouseup', handleVertexDragEnd);
+                document.removeEventListener('touchmove', handleVertexDrag);
+                document.removeEventListener('touchend', handleVertexDragEnd);
+            };
+        }
+    }, [activeVertex, imageBounds]);
+
+    const calculateImageBounds = () => {
+        if (imgRef.current && svgRef.current) {
+            const img = imgRef.current;
+            const svg = svgRef.current;
+            const svgRect = svg.getBoundingClientRect();
+            
+            const imgAspectRatio = img.naturalWidth / img.naturalHeight;
+            const containerAspectRatio = svgRect.width / svgRect.height;
+            
+            let imageWidth, imageHeight, imageX, imageY;
+            
+            if (imgAspectRatio > containerAspectRatio) {
+                imageWidth = svgRect.width;
+                imageHeight = svgRect.width / imgAspectRatio;
+                imageX = 0;
+                imageY = (svgRect.height - imageHeight) / 2;
+            } else {
+                imageHeight = svgRect.height;
+                imageWidth = svgRect.height * imgAspectRatio;
+                imageX = (svgRect.width - imageWidth) / 2;
+                imageY = 0;
+            }
+
+            const bounds = { x: imageX, y: imageY, width: imageWidth, height: imageHeight };
+            setImageBounds(bounds);
+            
+            if (vertices.length === 0) {
+                setVertices([
+                    { x: imageX, y: imageY },
+                    { x: imageX + imageWidth, y: imageY },
+                    { x: imageX + imageWidth, y: imageY + imageHeight },
+                    { x: imageX, y: imageY + imageHeight }
+                ]);
+            }
+        }
+    };
+
+    useEffect(() => {
+        const img = imgRef.current;
+        if (img) {
+            if (img.complete) {
+                calculateImageBounds();
+            } else {
+                img.onload = calculateImageBounds;
+            }
+        }
+
+        window.addEventListener('resize', calculateImageBounds);
+        return () => window.removeEventListener('resize', calculateImageBounds);
+    }, []);
+
+    const handleVertexDrag = (e: MouseEvent | TouchEvent) => {
+        if (activeVertex === null || !svgRef.current || !imageBounds) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const svgRect = svgRef.current.getBoundingClientRect();
+        
+        const clientX = 'touches' in e ? (e as TouchEvent).touches[0].clientX : (e as MouseEvent).clientX;
+        const clientY = 'touches' in e ? (e as TouchEvent).touches[0].clientY : (e as MouseEvent).clientY;
+
+        let x = clientX - svgRect.left;
+        let y = clientY - svgRect.top;
+
+        x = Math.max(imageBounds.x, Math.min(x, imageBounds.x + imageBounds.width));
+        y = Math.max(imageBounds.y, Math.min(y, imageBounds.y + imageBounds.height));
+
+        setVertices(prev => {
+            const updated = [...prev];
+            updated[activeVertex] = { x, y };
+            return updated;
+        });
+    };
+
+    const handleVertexDragStart = (index: number) => {
+        setActiveVertex(index);
+    };
+
+    const handleVertexDragEnd = () => {
+        setActiveVertex(null);
+    };
+
+    const handleConfirm = () => {
+        updatePhotoVertices(photoId, vertices);
+        navigate(-1);
+    };
+
+    return (
+        <div className="z-50 w-full h-[896px] flex flex-col select-none">
+            <NavBar
+                title="영역 설정"
+                hideLeftIcon={false}
+                showMenu={false}
+                iconNames={{
+                    backIcon: "뒤로가기"
+                }}
+                rightIcons={[]}
+            />
+            
+            {/* flex-1 제거하고 고정 높이 사용 */}
+            <div className="relative w-[414px] h-[615px] bg-gray-900">
+                <img
+                    ref={imgRef}
+                    src={photoData}
+                    alt="scanned"
+                    className="w-full h-full object-cover"
+                />
+                
+                <svg
+                    ref={svgRef}
+                    className="absolute top-0 left-0 w-full h-full"
+                    style={{ touchAction: 'none' }}
+                >
+                    {vertices.length > 0 && imageBounds && (
+                        <>
+                            <path
+                                d={`M ${vertices.map(v => `${v.x},${v.y}`).join(' L ')} Z`}
+                                stroke="#2563EB"
+                                strokeWidth="2"
+                                fill="none"
+                            />
+                            
+                            {vertices.map((vertex, index) => (
+                                <circle
+                                    key={index}
+                                    cx={vertex.x}
+                                    cy={vertex.y}
+                                    stroke="#2563EB"
+                                    strokeWidth={3}
+                                    r="10"
+                                    fill="#2563EB"
+                                    className="cursor-move"
+                                    style={{ pointerEvents: 'auto' }}
+                                    onMouseDown={(e) => {
+                                        e.stopPropagation();
+                                        handleVertexDragStart(index);
+                                    }}
+                                    onTouchStart={(e) => {
+                                        e.stopPropagation();
+                                        handleVertexDragStart(index);
+                                    }}
+                                />
+                            ))}
+                        </>
+                    )}
+                </svg>
+            </div>
+
+            <div className="flex justify-center bg-[#181A20] flex-col h-[187.5px]">
+                <button
+                    onClick={handleConfirm}
+                    className="mx-auto  text-white text-[25px] font-bold"
+                >
+                    영역 설정 완료
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default ScanVertex;

--- a/src/routes/constants.ts
+++ b/src/routes/constants.ts
@@ -24,6 +24,11 @@ export const ROUTES = {
         title: 'Scan',
         ko: '스캔'
     },
+    SCANVERTEX: {
+        path:'/scan/vertex',
+        title: 'Scan Vertex',
+        ko: '영역 조정'
+    },
     LIBRARY: {
         BOOK: {
             path: '/library/book',


### PR DESCRIPTION
## 📗 작업 내용
- ScanVertex 페이지 관련 작업


### ✅ PR 타입
- [x] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
- ScanVertex 페이지 퍼블리싱 완료
- zustand를 사용해 ScanVertex 페이지를 위한 전역 변수 저장
- 스캔 페이지에 ScanVertex로 이동하는 경로 추가
- ScanVertex 페이지 라우트 추가
- 백엔드에 정점 정보 보내기 위해 코드 수정
- 스캔 페이지 정점에 대한 정보 formData에 추가

### ✅ 참고 사항
-

### 📸 작업 미리보기
- 

### 🔥  회고
- 
