### PR TITLE
📕 #53 변환 완료시 보관함 이동 전 사진 배열 초기화

### DIFF
--- a/src/components/scan/BookConvertModal.tsx
+++ b/src/components/scan/BookConvertModal.tsx
@@ -16,6 +16,7 @@ interface BookConvertModalProps {
     onUpload: (photos: PhotoFile[], title: string) => Promise<boolean>;
     onComplete: () => void;
     isLoading: boolean;
+    clearPhotos: () => void;
 }
 
 const BookConvertModal: React.FC<BookConvertModalProps> = ({
@@ -24,6 +25,7 @@ const BookConvertModal: React.FC<BookConvertModalProps> = ({
                                                                 onUpload,
                                                                 onComplete,
                                                                 isLoading,
+                                                                clearPhotos,
                                                             }) => {
     const navigate = useNavigate();
     const [step, setStep] = useState<number>(1);
@@ -166,7 +168,7 @@ const BookConvertModal: React.FC<BookConvertModalProps> = ({
             <div className="flex justify-center space-x-4">
                 <button
                     onClick={() => {
-                        onComplete();
+                        clearPhotos();
                         navigate("/library/book");
                     }}
                     className="flex justify-center items-center w-[100px] h-[35px] bg-blue-600 text-white rounded-3xl font-[15px] hover:bg-blue-700"

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -84,6 +84,7 @@ const Scan = () => {
             onUpload: handleUpload,
             onComplete: handleUploadComplete,
             isLoading: isLoading,
+            clearPhotos: clearStorePhotos
         };
 
         switch (scanType) {


### PR DESCRIPTION
## 📗 작업 내용
- 변환 완료시 보관함 이동 전 사진 배열 초기화


### ✅ PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
- clearStorePhotos를 활용해 clearPhotos 함수 추가 후 배열 초기화

### ✅ 참고 사항
-

### 📸 작업 미리보기
- 

### 🔥  회고
- 
