### PR TITLE
📕 #66 ScanVertex 페이지 이미지 바운드, 버텍스 컨트롤 훅으로 분리

### DIFF
--- a/src/hooks/useImageBounds.ts
+++ b/src/hooks/useImageBounds.ts
@@ -1,0 +1,131 @@
+// 원본 이미지의 크기를 유지하면서 컨테이너에 맞게 이미지의 크기를 조절함
+import { useState, useEffect, RefObject } from 'react';
+
+// 이미지의 경계와 크기 정보를 나타내는 인터페이스
+interface ImageBounds {
+    x: number;          // 이미지의 왼쪽 위치
+    y: number;          // 이미지의 상단 위치
+    width: number;      // 이미지의 너비
+    height: number;     // 이미지의 높이
+    scale: number;      // 이미지의 스케일(확대/축소 비율)
+}
+
+// 훅의 입력 props 인터페이스
+interface UseImageBoundsProps {
+    imgRef: RefObject<HTMLImageElement>;     // 이미지 요소에 대한 참조
+    containerRef: RefObject<HTMLDivElement>; // 이미지를 감싸는 컨테이너 요소에 대한 참조
+    onBoundsCalculated?: (                   // 경계가 계산되었을 때 호출되는 콜백 함수
+        bounds: ImageBounds,                 // 계산된 경계 정보
+        originalSize: { width: number; height: number }  // 원본 이미지 크기
+    ) => void;
+}
+
+// 훅의 반환 값 인터페이스
+interface UseImageBoundsReturn {
+    imageBounds: ImageBounds | null;        // 계산된 이미지 경계 정보
+    originalImageSize: { width: number; height: number } | null;  // 원본 이미지 크기
+    calculateImageBounds: () => void;        // 경계를 재계산하는 함수
+}
+
+export const useImageBounds = ({
+    imgRef,
+    containerRef,
+    onBoundsCalculated
+}: UseImageBoundsProps): UseImageBoundsReturn => {
+    // 이미지 경계 정보 상태
+    const [imageBounds, setImageBounds] = useState<ImageBounds | null>(null);
+    // 원본 이미지 크기 상태
+    const [originalImageSize, setOriginalImageSize] = useState<{ width: number; height: number } | null>(null);
+
+    // 이미지 스케일을 계산하는 함수
+    // 컨테이너 크기에 맞게 이미지를 비율을 유지하면서 맞추기 위한 계산
+    const calculateImageScale = (
+        imgWidth: number,       // 원본 이미지 너비
+        imgHeight: number,      // 원본 이미지 높이
+        containerWidth: number, // 컨테이너 너비
+        containerHeight: number // 컨테이너 높이
+    ) => {
+        // 너비와 높이의 스케일 계산
+        const widthScale = containerWidth / imgWidth;
+        const heightScale = containerHeight / imgHeight;
+        // 더 작은 스케일을 반환 (이미지가 컨테이너를 벗어나지 않도록)
+        return Math.min(widthScale, heightScale);
+    };
+
+    // 이미지 경계를 계산하는 함수
+    const calculateImageBounds = () => {
+        if (!imgRef.current || !containerRef.current) return;
+
+        const img = imgRef.current;
+        const container = containerRef.current;
+        const containerRect = container.getBoundingClientRect();
+
+        // 원본 이미지 크기 가져오기
+        const imgNaturalWidth = img.naturalWidth;
+        const imgNaturalHeight = img.naturalHeight;
+        const originalSize = { width: imgNaturalWidth, height: imgNaturalHeight };
+        setOriginalImageSize(originalSize);
+
+        // 이미지 스케일 계산
+        const scale = calculateImageScale(
+            imgNaturalWidth,
+            imgNaturalHeight,
+            containerRect.width,
+            containerRect.height
+        );
+
+        // 스케일이 적용된 이미지 크기 계산
+        const scaledWidth = imgNaturalWidth * scale;
+        const scaledHeight = imgNaturalHeight * scale;
+
+        // 이미지를 컨테이너 중앙에 위치시키기 위한 오프셋 계산
+        const offsetX = (containerRect.width - scaledWidth) / 2;
+        const offsetY = (containerRect.height - scaledHeight) / 2;
+
+        // 최종 경계 정보 생성
+        const bounds = {
+            x: offsetX,
+            y: offsetY,
+            width: scaledWidth,
+            height: scaledHeight,
+            scale: scale
+        };
+
+        // 상태 업데이트 및 콜백 호출
+        setImageBounds(bounds);
+        onBoundsCalculated?.(bounds, originalSize);
+    };
+
+    // 이미지 로드 및 리사이즈 이벤트 처리
+    useEffect(() => {
+        const img = imgRef.current;
+        if (img) {
+            // 이미지가 이미 로드되어 있으면 바로 계산
+            if (img.complete) {
+                calculateImageBounds();
+            } else {
+                // 아니면 로드 완료 시 계산
+                img.onload = calculateImageBounds;
+            }
+        }
+
+        // 윈도우 리사이즈 이벤트 처리
+        const handleResize = () => {
+            calculateImageBounds();
+        };
+
+        // 리사이즈 이벤트 리스너 등록
+        window.addEventListener('resize', handleResize);
+        // 클린업 함수에서 리스너 제거
+        return () => window.removeEventListener('resize', handleResize);
+    }, []); // 의존성 배열이 비어있어 마운트 시에만 실행
+
+    // 훅의 반환 값
+    return {
+        imageBounds,
+        originalImageSize,
+        calculateImageBounds
+    };
+};
+
+export default useImageBounds;

--- a/src/hooks/useVertexControl.ts
+++ b/src/hooks/useVertexControl.ts
@@ -1,0 +1,183 @@
+// 사용자가 드래그할 수 있는 4개의 꼭지점을 제어함
+import { useState, useEffect, RefObject } from 'react';
+
+// 꼭지점(vertex)의 좌표를 나타내는 인터페이스
+export interface Vertex {
+    x: number;
+    y: number;
+}
+
+// 이미지의 경계와 크기 정보를 나타내는 인터페이스
+interface ImageBounds {
+    x: number;          // 이미지의 x 좌표
+    y: number;          // 이미지의 y 좌표
+    width: number;      // 이미지의 너비
+    height: number;     // 이미지의 높이
+    scale: number;      // 이미지의 스케일(확대/축소 비율)
+}
+
+// 훅의 props 인터페이스
+interface UseVertexControlProps {
+    svgRef: RefObject<SVGSVGElement>;              // SVG 요소에 대한 참조
+    imageBounds: ImageBounds | null;               // 이미지 경계 정보
+    originalImageSize: { width: number; height: number } | null;  // 원본 이미지 크기
+}
+
+// 훅의 반환 값 인터페이스
+interface UseVertexControlReturn {
+    vertices: Vertex[];             // 모든 꼭지점들의 배열
+    setVertices: React.Dispatch<React.SetStateAction<Vertex[]>>;  // 꼭지점 배열을 업데이트하는 함수
+    activeVertex: number | null;    // 현재 활성화된(드래그 중인) 꼭지점의 인덱스
+    isDragging: boolean;            // 드래그 중인지 여부
+    handleVertexDragStart: (index: number, e: React.MouseEvent | React.TouchEvent) => void;  // 드래그 시작 핸들러
+    screenToImageCoordinates: (screenX: number, screenY: number) => Vertex;  // 화면 좌표를 이미지 좌표로 변환
+}
+
+export const useVertexControl = ({
+    svgRef,
+    imageBounds,
+    originalImageSize
+}: UseVertexControlProps): UseVertexControlReturn => {
+    // 상태 관리
+    const [vertices, setVertices] = useState<Vertex[]>([]); // 꼭지점들의 배열
+    const [activeVertex, setActiveVertex] = useState<number | null>(null); // 현재 드래그 중인 꼭지점
+    const [isDragging, setIsDragging] = useState(false); // 드래그 상태
+
+    // 마우스/터치 이벤트의 좌표를 일관된 형식으로 반환하는 유틸리티 함수
+    const getEventCoordinates = (e: MouseEvent | TouchEvent): { clientX: number; clientY: number } => {
+        if ('touches' in e) {
+            // 터치 이벤트인 경우
+            const touch = e.touches[0];
+            return {
+                clientX: touch.clientX,
+                clientY: touch.clientY
+            };
+        }
+        // 마우스 이벤트인 경우
+        return {
+            clientX: (e as MouseEvent).clientX,
+            clientY: (e as MouseEvent).clientY
+        };
+    };
+
+    // 꼭지점 드래그 중 처리하는 함수
+    const handleVertexDrag = (e: MouseEvent | TouchEvent) => {
+        if (activeVertex === null || !svgRef.current || !imageBounds) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        // 이벤트의 좌표 가져오기
+        const { clientX, clientY } = getEventCoordinates(e);
+        const svgRect = svgRef.current.getBoundingClientRect();
+
+        // 화면 좌표를 SVG 내부 좌표로 변환
+        let screenX = clientX - svgRect.left;
+        let screenY = clientY - svgRect.top;
+
+        // 좌표가 이미지 경계를 벗어나지 않도록 제한
+        screenX = Math.max(imageBounds.x, Math.min(screenX, imageBounds.x + imageBounds.width));
+        screenY = Math.max(imageBounds.y, Math.min(screenY, imageBounds.y + imageBounds.height));
+
+        // 꼭지점 위치 업데이트
+        setVertices(prev => {
+            const updated = [...prev];
+            updated[activeVertex] = { x: screenX, y: screenY };
+            return updated;
+        });
+    };
+
+    // 꼭지점 드래그 시작 처리 함수
+    const handleVertexDragStart = (index: number, e: React.MouseEvent | React.TouchEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setActiveVertex(index);
+        setIsDragging(true);
+
+        // 터치 이벤트 처리
+        if (e.type === 'touchstart') {
+            const touch = (e as React.TouchEvent).touches[0];
+            const svgRect = svgRef.current?.getBoundingClientRect();
+            if (svgRect && touch) {
+                const screenX = touch.clientX - svgRect.left;
+                const screenY = touch.clientY - svgRect.top;
+                setVertices(prev => {
+                    const updated = [...prev];
+                    updated[index] = { x: screenX, y: screenY };
+                    return updated;
+                });
+            }
+        }
+    };
+
+    // 드래그 종료 처리 함수
+    const handleVertexDragEnd = () => {
+        setActiveVertex(null);
+        setIsDragging(false);
+    };
+
+    // 화면 좌표를 이미지 좌표로 변환하는 함수
+    const screenToImageCoordinates = (screenX: number, screenY: number): Vertex => {
+        if (!imageBounds || !originalImageSize) return { x: screenX, y: screenY };
+
+        // 상대적 위치 계산
+        const relativeX = (screenX - imageBounds.x) / imageBounds.scale;
+        const relativeY = (screenY - imageBounds.y) / imageBounds.scale;
+
+        // 이미지 경계 내로 제한
+        return {
+            x: Math.max(0, Math.min(originalImageSize.width, relativeX)),
+            y: Math.max(0, Math.min(originalImageSize.height, relativeY))
+        };
+    };
+
+    // 드래그 중 스크롤 방지 효과
+    useEffect(() => {
+        const preventDefault = (e: TouchEvent | WheelEvent) => {
+            if (isDragging) {
+                e.preventDefault();
+            }
+        };
+
+        if (isDragging) {
+            document.body.style.overflow = 'hidden';
+            document.addEventListener('touchmove', preventDefault, { passive: false });
+            document.addEventListener('wheel', preventDefault, { passive: false });
+        }
+
+        return () => {
+            document.body.style.overflow = 'auto';
+            document.removeEventListener('touchmove', preventDefault);
+            document.removeEventListener('wheel', preventDefault);
+        };
+    }, [isDragging]);
+
+    // 꼭지점 드래그 이벤트 리스너 설정
+    useEffect(() => {
+        if (activeVertex !== null) {
+            // 드래그 중일 때만 이벤트 리스너 추가
+            document.addEventListener('mousemove', handleVertexDrag);
+            document.addEventListener('mouseup', handleVertexDragEnd);
+            document.addEventListener('touchmove', handleVertexDrag, { passive: false });
+            document.addEventListener('touchend', handleVertexDragEnd);
+
+            // 컴포넌트 언마운트 또는 드래그 종료 시 이벤트 리스너 제거
+            return () => {
+                document.removeEventListener('mousemove', handleVertexDrag);
+                document.removeEventListener('mouseup', handleVertexDragEnd);
+                document.removeEventListener('touchmove', handleVertexDrag);
+                document.removeEventListener('touchend', handleVertexDragEnd);
+            };
+        }
+    }, [activeVertex, imageBounds]);
+
+    // 훅의 반환 값
+    return {
+        vertices,
+        setVertices,
+        activeVertex,
+        isDragging,
+        handleVertexDragStart,
+        screenToImageCoordinates
+    };
+};

--- a/src/pages/ScanVertex.tsx
+++ b/src/pages/ScanVertex.tsx
@@ -1,24 +1,13 @@
-import React, {useState, useEffect, useRef} from 'react';
-import {useNavigate, useLocation, useParams} from 'react-router-dom';
-import {NavBar} from '../components/common/NavBar';
-import {useScanStore} from '../hooks/useScanStore';
-
-interface Vertex {
-    x: number;
-    y: number;
-}
+import React, { useRef } from 'react';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { NavBar } from '../components/common/NavBar';
+import { useScanStore } from '../hooks/useScanStore';
+import { useVertexControl } from '../hooks/useVertexControl';
+import { useImageBounds } from '../hooks/useImageBounds';
 
 interface LocationState {
     photoId: string;
     photoData: string;
-}
-
-interface ImageBounds {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-    scale: number;
 }
 
 const ScanVertex: React.FC = () => {
@@ -28,231 +17,81 @@ const ScanVertex: React.FC = () => {
     const svgRef = useRef<SVGSVGElement>(null);
     const imgRef = useRef<HTMLImageElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
-    const {photoId, photoData} = location.state as LocationState;
-    const {updatePhotoVertices} = useScanStore();
-    const [vertices, setVertices] = useState<Vertex[]>([]);
-    const [activeVertex, setActiveVertex] = useState<number | null>(null);
-    const [imageBounds, setImageBounds] = useState<ImageBounds | null>(null);
-    const [originalImageSize, setOriginalImageSize] = useState<{ width: number; height: number } | null>(null);
-    const [isDragging, setIsDragging] = useState(false);
+    const { photoId, photoData } = location.state as LocationState;
+    const { updatePhotoVertices } = useScanStore();
 
-    // Prevent scroll when dragging
-    useEffect(() => {
-        const preventDefault = (e: TouchEvent | WheelEvent) => {
-            if (isDragging) {
-                e.preventDefault();
-            }
-        };
+    const {
+        imageBounds,
+        originalImageSize,
+    } = useImageBounds({
+        imgRef,
+        containerRef,
+        onBoundsCalculated: (bounds, originalSize) => {
+            // 안쪽으로 들어온 여백 설정
+            const PADDING = 40;
+            const paddedOffsetX = bounds.x + PADDING;
+            const paddedOffsetY = bounds.y + PADDING;
+            const paddedWidth = bounds.width - (PADDING * 2);
+            const paddedHeight = bounds.height - (PADDING * 2);
 
-        if (isDragging) {
-            document.body.style.overflow = 'hidden';
-            document.addEventListener('touchmove', preventDefault, {passive: false});
-            document.addEventListener('wheel', preventDefault, {passive: false});
-        }
-
-        return () => {
-            document.body.style.overflow = 'auto';
-            document.removeEventListener('touchmove', preventDefault);
-            document.removeEventListener('wheel', preventDefault);
-        };
-    }, [isDragging]);
-
-    const calculateImageScale = (imgWidth: number, imgHeight: number, containerWidth: number, containerHeight: number) => {
-        const widthScale = containerWidth / imgWidth;
-        const heightScale = containerHeight / imgHeight;
-        return Math.min(widthScale, heightScale);
-    };
-
-    const screenToImageCoordinates = (screenX: number, screenY: number): Vertex => {
-        if (!imageBounds || !originalImageSize) return {x: screenX, y: screenY};
-
-        const relativeX = (screenX - imageBounds.x) / imageBounds.scale;
-        const relativeY = (screenY - imageBounds.y) / imageBounds.scale;
-
-        return {
-            x: Math.max(0, Math.min(originalImageSize.width, relativeX)),
-            y: Math.max(0, Math.min(originalImageSize.height, relativeY))
-        };
-    };
-
-    const calculateImageBounds = () => {
-        if (!imgRef.current || !svgRef.current || !containerRef.current) return;
-
-        const img = imgRef.current;
-        const container = containerRef.current;
-        const containerRect = container.getBoundingClientRect();
-
-        const imgNaturalWidth = img.naturalWidth;
-        const imgNaturalHeight = img.naturalHeight;
-        setOriginalImageSize({width: imgNaturalWidth, height: imgNaturalHeight});
-
-        const scale = calculateImageScale(
-            imgNaturalWidth,
-            imgNaturalHeight,
-            containerRect.width,
-            containerRect.height
-        );
-
-        const scaledWidth = imgNaturalWidth * scale;
-        const scaledHeight = imgNaturalHeight * scale;
-
-        const offsetX = (containerRect.width - scaledWidth) / 2;
-        const offsetY = (containerRect.height - scaledHeight) / 2;
-
-        const bounds = {
-            x: offsetX,
-            y: offsetY,
-            width: scaledWidth,
-            height: scaledHeight,
-            scale: scale
-        };
-
-        setImageBounds(bounds);
-
-        // 안쪽으로 들어온 여백 설정
-        const PADDING = 40;
-        const paddedOffsetX = offsetX + PADDING;
-        const paddedOffsetY = offsetY + PADDING;
-        const paddedWidth = scaledWidth - (PADDING * 2);
-        const paddedHeight = scaledHeight - (PADDING * 2);
-
-        if (vertices.length === 0) {
-            setVertices([
-                {x: paddedOffsetX, y: paddedOffsetY}, // 좌상단
-                {x: paddedOffsetX + paddedWidth, y: paddedOffsetY}, // 우상단
-                {x: paddedOffsetX + paddedWidth, y: paddedOffsetY + paddedHeight}, // 우하단
-                {x: paddedOffsetX, y: paddedOffsetY + paddedHeight} // 좌하단
-            ]);
-        } else {
-            const updatedVertices = vertices.map(vertex => {
-                const normalizedX = (vertex.x - bounds.x) / bounds.scale;
-                const normalizedY = (vertex.y - bounds.y) / bounds.scale;
-                return {
-                    x: normalizedX * scale + offsetX,
-                    y: normalizedY * scale + offsetY
-                };
-            });
-            setVertices(updatedVertices);
-        }
-    };
-
-    useEffect(() => {
-        const img = imgRef.current;
-        if (img) {
-            if (img.complete) {
-                calculateImageBounds();
+            if (vertices.length === 0) {
+                setVertices([
+                    { x: paddedOffsetX, y: paddedOffsetY }, // 좌상단
+                    { x: paddedOffsetX + paddedWidth, y: paddedOffsetY }, // 우상단
+                    { x: paddedOffsetX + paddedWidth, y: paddedOffsetY + paddedHeight }, // 우하단
+                    { x: paddedOffsetX, y: paddedOffsetY + paddedHeight } // 좌하단
+                ]);
             } else {
-                img.onload = calculateImageBounds;
-            }
-        }
-
-        const handleResize = () => {
-            calculateImageBounds();
-        };
-
-        window.addEventListener('resize', handleResize);
-        return () => window.removeEventListener('resize', handleResize);
-    }, []);
-
-    const getEventCoordinates = (e: MouseEvent | TouchEvent): { clientX: number; clientY: number } => {
-        if ('touches' in e) {
-            const touch = e.touches[0];
-            return {
-                clientX: touch.clientX,
-                clientY: touch.clientY
-            };
-        }
-        return {
-            clientX: (e as MouseEvent).clientX,
-            clientY: (e as MouseEvent).clientY
-        };
-    };
-
-    const handleVertexDrag = (e: MouseEvent | TouchEvent) => {
-        if (activeVertex === null || !svgRef.current || !imageBounds) return;
-
-        e.preventDefault();
-        e.stopPropagation();
-
-        const {clientX, clientY} = getEventCoordinates(e);
-        const svgRect = svgRef.current.getBoundingClientRect();
-
-        let screenX = clientX - svgRect.left;
-        let screenY = clientY - svgRect.top;
-
-        screenX = Math.max(imageBounds.x, Math.min(screenX, imageBounds.x + imageBounds.width));
-        screenY = Math.max(imageBounds.y, Math.min(screenY, imageBounds.y + imageBounds.height));
-
-        setVertices(prev => {
-            const updated = [...prev];
-            updated[activeVertex] = {x: screenX, y: screenY};
-            return updated;
-        });
-    };
-
-    const handleVertexDragStart = (index: number, e: React.MouseEvent | React.TouchEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-        setActiveVertex(index);
-        setIsDragging(true);
-
-        if (e.type === 'touchstart') {
-            const touch = (e as React.TouchEvent).touches[0];
-            const svgRect = svgRef.current?.getBoundingClientRect();
-            if (svgRect && touch) {
-                const screenX = touch.clientX - svgRect.left;
-                const screenY = touch.clientY - svgRect.top;
-                setVertices(prev => {
-                    const updated = [...prev];
-                    updated[index] = {x: screenX, y: screenY};
-                    return updated;
+                const updatedVertices = vertices.map(vertex => {
+                    const normalizedX = (vertex.x - bounds.x) / bounds.scale;
+                    const normalizedY = (vertex.y - bounds.y) / bounds.scale;
+                    return {
+                        x: normalizedX * bounds.scale + bounds.x,
+                        y: normalizedY * bounds.scale + bounds.y
+                    };
                 });
+                setVertices(updatedVertices);
             }
         }
-    };
+    });
 
-    const handleVertexDragEnd = () => {
-        setActiveVertex(null);
-        setIsDragging(false);
-    };
-
-    useEffect(() => {
-        if (activeVertex !== null) {
-            document.addEventListener('mousemove', handleVertexDrag);
-            document.addEventListener('mouseup', handleVertexDragEnd);
-            document.addEventListener('touchmove', handleVertexDrag, {passive: false});
-            document.addEventListener('touchend', handleVertexDragEnd);
-
-            return () => {
-                document.removeEventListener('mousemove', handleVertexDrag);
-                document.removeEventListener('mouseup', handleVertexDragEnd);
-                document.removeEventListener('touchmove', handleVertexDrag);
-                document.removeEventListener('touchend', handleVertexDragEnd);
-            };
-        }
-    }, [activeVertex, imageBounds]);
+    const {
+        vertices,
+        setVertices,
+        activeVertex,
+        handleVertexDragStart,
+        screenToImageCoordinates
+    } = useVertexControl({
+        svgRef,
+        imageBounds,
+        originalImageSize
+    });
 
     const handleConfirm = async () => {
         if (!imageBounds || !originalImageSize) return;
-
+    
         const normalizedVertices = vertices.map(vertex =>
             screenToImageCoordinates(vertex.x, vertex.y)
         );
-
+    
         try {
             await updatePhotoVertices(photoId, normalizedVertices, photoData);
-
-            navigate(`/scan/${type}`,
-                {
-                    replace: true,
-                    state: {
-                        fromVertex: true,
+            
+            navigate(`/scan/${type}`, {
+                replace: true,
+                state: {
+                    fromVertex: true,
+                    updatedPhoto: {
+                        id: photoId,
+                        data: photoData,
+                        vertices: normalizedVertices
                     }
-                });
-        } catch(e){
-            console.log((e)) 
+                }
+            });
+        } catch (e) {
+            console.log(e);
         }
-        }
+    };
 
     return (
         <div className="z-50 mt-[15px] w-full h-[896px] flex flex-col select-none">
@@ -283,18 +122,18 @@ const ScanVertex: React.FC = () => {
                     className="absolute top-0 left-0 w-full h-full"
                 >
                     {vertices.length > 0 && imageBounds && (
-                        <g style={{pointerEvents: 'all'}}>
+                        <g style={{ pointerEvents: 'all' }}>
                             <path
                                 d={`M ${vertices.map(v => `${v.x},${v.y}`).join(' L ')} Z`}
                                 stroke="#2563EB"
                                 strokeWidth="3"
                                 fill="rgba(37, 99, 235, 0.2)"
-                                style={{pointerEvents: 'none'}}
+                                style={{ pointerEvents: 'none' }}
                             />
 
                             {vertices.map((vertex, index) => (
                                 <g key={index}
-                                   style={{cursor: 'pointer'}}>
+                                   style={{ cursor: 'pointer' }}>
                                     <circle
                                         cx={vertex.x}
                                         cy={vertex.y}
@@ -310,7 +149,7 @@ const ScanVertex: React.FC = () => {
                                         fill="#246BFD"
                                         stroke="#ffffff"
                                         strokeWidth="2"
-                                        style={{pointerEvents: 'none'}}
+                                        style={{ pointerEvents: 'none' }}
                                     />
                                     {activeVertex === index && (
                                         <circle
@@ -321,7 +160,7 @@ const ScanVertex: React.FC = () => {
                                             stroke="#2563EB"
                                             strokeWidth="2"
                                             opacity="0.5"
-                                            style={{pointerEvents: 'none'}}
+                                            style={{ pointerEvents: 'none' }}
                                         />
                                     )}
                                 </g>


### PR DESCRIPTION
## 📗 작업 내용
- ScanVertex 페이지 이미지 바운드, 버텍스 컨트롤 훅으로 분리


### ✅ PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### ✅ 변경 사항
- 

### ✅ 참고 사항
-

### 📸 작업 미리보기
- 

### 🔥  회고
- 
